### PR TITLE
improve timestamp formatting

### DIFF
--- a/chug/prettify.go
+++ b/chug/prettify.go
@@ -114,7 +114,7 @@ func (s *stenographer) PrettyPrintLog(log chug.LogEntry) {
 
 	var timestamp string
 	if s.Absolute {
-		timestamp = log.Timestamp.Format("01/02 15:04:05.00")
+		timestamp = log.Timestamp.Format("02/01/06 15:04:05.99 MST")
 	} else {
 		timestamp = log.Timestamp.Sub(s.RelativeTime).String()
 		timestamp = fmt.Sprintf("%17s", timestamp)

--- a/chug/time_parser.go
+++ b/chug/time_parser.go
@@ -23,7 +23,7 @@ func ParseTimeFlag(t string) (time.Time, error) {
 		return time.Now().Add(duration), err
 	}
 
-	out, err := time.Parse("01/02 15:04:05.00", t)
+	out, err := time.Parse("02/01/06 15:04:05.99 MST", t)
 	if err == nil {
 		return out, err
 	}

--- a/chug/time_parser_test.go
+++ b/chug/time_parser_test.go
@@ -31,9 +31,9 @@ var _ = Describe("TimeParser", func() {
 
 	Context("when passed a chug-formatted timestamp", func() {
 		It("should return that time", func() {
-			expectedTime, err := time.Parse("01/02 15:04:05.00", "09/08 22:45:06.79")
+			expectedTime, err := time.Parse("02/01/06 15:04:05.99 MST", "10/03/17 07:35:14.43 PST")
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(ParseTimeFlag("09/08 22:45:06.79")).Should(Equal(expectedTime))
+			Expect(ParseTimeFlag("10/03/17 07:35:14.43 PST")).Should(Equal(expectedTime))
 		})
 	})
 

--- a/main.go
+++ b/main.go
@@ -17,8 +17,10 @@ func main() {
 
 	commandGroups := []common.CommandGroup{
 		common.CommandGroup{
-			Name:        "Chug",
-			Description: "Commands to prettify lager logs",
+			Name: "Chug",
+			Description: `Commands to prettify lager logs
+Note: A chug-formatted time looks like 02/01/06 15:04:05.99 MST
+`,
 			Commands: []common.Command{
 				chug.ChugCommand(),
 				chug.ServeChugCommand(),


### PR DESCRIPTION
hey @benmoss 

After struggling while analyzing some logs during a support incident, I made this specific change on my local fork of Veritas to make dealing with timestamps a little more consistent and sane.